### PR TITLE
Update pawns.md

### DIFF
--- a/docs/kh3/pawns.md
+++ b/docs/kh3/pawns.md
@@ -593,6 +593,7 @@ Some maps overrides the pawn path contained in the save data, loading an hard co
 | w_so144 | Grand Chef Pan (?)
 | w_so145 | Grand Chef Pan (?)
 | w_so150 | Starlight
+| w_so160 | Midnight Blue
 | w_so170 | Nano Gear
 | w_so172 | Nano Gear Formchanges
 | w_so173 | Nano Gear Fist


### PR DESCRIPTION
Found PS4 exclusive keyblade, Midnight Blue's effects under w_so160 in the PC version, so technically that is what Midnight Blue's Pawn ID is.